### PR TITLE
fix: installation example

### DIFF
--- a/docs/Programming Language/python/libs/fastapi.md
+++ b/docs/Programming Language/python/libs/fastapi.md
@@ -3,7 +3,11 @@
 ## Installation
 
 ```bash linenums="1"
-pip install fastapi[all] uvicorn[standard]
+pip install fastapi[all]
+
+or
+
+pip install fastapi uvicorn[standard]
 ```
 
 Test to see if it installed successfully


### PR DESCRIPTION
fastapi[all] includes uvicorn[standard] and other packages.